### PR TITLE
Display days with empty data in the confirmed charts

### DIFF
--- a/components/confirmed-chart.js
+++ b/components/confirmed-chart.js
@@ -10,7 +10,18 @@ const options = {
   },
   scales: {
     xAxes: [{
-      stacked: true
+      stacked: true,
+      type: 'time',
+      time: {
+        unit: 'day',
+        displayFormats: {
+          day: 'YYYY-MM-DD'
+        }
+      },
+      gridLines: {
+        offsetGridLines: true
+      },
+      offset: true
     }],
     yAxes: [{
       stacked: true
@@ -38,7 +49,7 @@ const formatData = data => {
   }
 
   return {
-    labels: data.map(h => h.date),
+    labels: data.map(h => new Date(h.date)),
     datasets
   }
 }


### PR DESCRIPTION
Suite à #10 voici une PR pour afficher des colonnes vides pour les jours pour lesquels il n'y a pas de données :

<img width="358" alt="Capture d’écran 2020-03-16 à 13 20 20" src="https://user-images.githubusercontent.com/167767/76758064-32484900-6789-11ea-8cb6-6ebb81d5be49.png">
