### PR TITLE
Ajout de nouvelles métriques (Réanimation, Hospitalisés)

### DIFF
--- a/components/charts/hospitalises-chart.js
+++ b/components/charts/hospitalises-chart.js
@@ -31,7 +31,7 @@ const formatData = data => {
 
   if (data.some(h => h.hospitalises)) {
     datasets.push({
-      label: 'Réanimation',
+      label: 'Hospitalisés',
       data: data.map(h => h.hospitalises),
       backgroundColor: colors.darkGrey
     })

--- a/components/charts/hospitalises-chart.js
+++ b/components/charts/hospitalises-chart.js
@@ -10,7 +10,6 @@ const options = {
   },
   scales: {
     xAxes: [{
-      stacked: true,
       type: 'time',
       time: {
         unit: 'day',
@@ -23,9 +22,6 @@ const options = {
         offsetGridLines: true
       },
       offset: true
-    }],
-    yAxes: [{
-      stacked: true
     }]
   }
 }
@@ -33,35 +29,11 @@ const options = {
 const formatData = data => {
   const datasets = []
 
-  if (data.some(h => h.reanimation)) {
-    datasets.push({
-      label: 'Réanimation',
-      data: data.map(h => h.reanimation),
-      backgroundColor: colors.darkerGrey
-    })
-  }
-
   if (data.some(h => h.hospitalises)) {
     datasets.push({
-      label: 'Hospitalisés',
+      label: 'Réanimation',
       data: data.map(h => h.hospitalises),
       backgroundColor: colors.darkGrey
-    })
-  }
-
-  if (data.some(h => h.casConfirmes)) {
-    datasets.push({
-      label: 'En vie',
-      data: data.map(h => h.casConfirmes - (h.deces || 0)),
-      backgroundColor: colors.orange
-    })
-  }
-
-  if (data.some(h => h.deces)) {
-    datasets.push({
-      label: 'Décédés',
-      data: data.map(h => h.deces),
-      backgroundColor: colors.red
     })
   }
 
@@ -71,19 +43,19 @@ const formatData = data => {
   }
 }
 
-const MixedChart = ({data, height}) => (
+const HospitalisesChart = ({data, height}) => (
   <div style={{padding: '1em'}}>
     <Bar data={formatData(data)} options={options} height={height} />
   </div>
 )
 
-MixedChart.defaultProps = {
+HospitalisesChart.defaultProps = {
   height: null
 }
 
-MixedChart.propTypes = {
+HospitalisesChart.propTypes = {
   data: PropTypes.array.isRequired,
   height: PropTypes.number
 }
 
-export default MixedChart
+export default HospitalisesChart

--- a/components/charts/mixed-chart.js
+++ b/components/charts/mixed-chart.js
@@ -33,19 +33,19 @@ const options = {
 const formatData = data => {
   const datasets = []
 
-  if (data.some(h => h.reanimation)) {
-    datasets.push({
-      label: 'Réanimation',
-      data: data.map(h => h.reanimation),
-      backgroundColor: colors.darkerGrey
-    })
-  }
-
   if (data.some(h => h.hospitalises)) {
     datasets.push({
       label: 'Hospitalisés',
       data: data.map(h => h.hospitalises),
       backgroundColor: colors.darkGrey
+    })
+  }
+
+  if (data.some(h => h.reanimation)) {
+    datasets.push({
+      label: 'Réanimation',
+      data: data.map(h => h.reanimation),
+      backgroundColor: colors.darkerGrey
     })
   }
 

--- a/components/charts/mixed-chart.js
+++ b/components/charts/mixed-chart.js
@@ -6,7 +6,13 @@ import colors from '../../styles/colors'
 
 const options = {
   tooltips: {
-    mode: 'index'
+    mode: 'index',
+    callbacks: {
+      label: (tooltipItem, data) => {
+        const datasetLabel = data.datasets[tooltipItem.datasetIndex].label
+        return tooltipItem.value === 'NaN' ? datasetLabel + ' : undefined' : datasetLabel + ' : ' + tooltipItem.value
+      }
+    }
   },
   scales: {
     xAxes: [{
@@ -73,7 +79,6 @@ const formatData = data => {
 
 const MixedChart = ({data, height}) => (
   <div style={{padding: '1em'}}>
-    {console.log(formatData(data))}
     <Bar data={formatData(data)} options={options} height={height} />
   </div>
 )

--- a/components/charts/mixed-chart.js
+++ b/components/charts/mixed-chart.js
@@ -33,6 +33,14 @@ const options = {
 const formatData = data => {
   const datasets = []
 
+  if (data.some(h => h.casConfirmes)) {
+    datasets.push({
+      label: 'Cas confirmés',
+      data: data.map(h => h.casConfirmes - ((h.deces + h.hospitalises + h.reanimation) || 0)),
+      backgroundColor: colors.orange
+    })
+  }
+
   if (data.some(h => h.hospitalises)) {
     datasets.push({
       label: 'Hospitalisés',
@@ -46,14 +54,6 @@ const formatData = data => {
       label: 'Réanimation',
       data: data.map(h => h.reanimation),
       backgroundColor: colors.darkerGrey
-    })
-  }
-
-  if (data.some(h => h.casConfirmes)) {
-    datasets.push({
-      label: 'Cas confirmés',
-      data: data.map(h => h.casConfirmes - (h.deces || 0)),
-      backgroundColor: colors.orange
     })
   }
 
@@ -73,6 +73,7 @@ const formatData = data => {
 
 const MixedChart = ({data, height}) => (
   <div style={{padding: '1em'}}>
+    {console.log(formatData(data))}
     <Bar data={formatData(data)} options={options} height={height} />
   </div>
 )

--- a/components/charts/mixed-chart.js
+++ b/components/charts/mixed-chart.js
@@ -51,7 +51,7 @@ const formatData = data => {
 
   if (data.some(h => h.casConfirmes)) {
     datasets.push({
-      label: 'En vie',
+      label: 'Cas confirmés',
       data: data.map(h => h.casConfirmes - (h.deces || 0)),
       backgroundColor: colors.orange
     })

--- a/components/charts/reanimation-chart.js
+++ b/components/charts/reanimation-chart.js
@@ -10,7 +10,6 @@ const options = {
   },
   scales: {
     xAxes: [{
-      stacked: true,
       type: 'time',
       time: {
         unit: 'day',
@@ -23,9 +22,6 @@ const options = {
         offsetGridLines: true
       },
       offset: true
-    }],
-    yAxes: [{
-      stacked: true
     }]
   }
 }
@@ -41,49 +37,25 @@ const formatData = data => {
     })
   }
 
-  if (data.some(h => h.hospitalises)) {
-    datasets.push({
-      label: 'Hospitalisés',
-      data: data.map(h => h.hospitalises),
-      backgroundColor: colors.darkGrey
-    })
-  }
-
-  if (data.some(h => h.casConfirmes)) {
-    datasets.push({
-      label: 'En vie',
-      data: data.map(h => h.casConfirmes - (h.deces || 0)),
-      backgroundColor: colors.orange
-    })
-  }
-
-  if (data.some(h => h.deces)) {
-    datasets.push({
-      label: 'Décédés',
-      data: data.map(h => h.deces),
-      backgroundColor: colors.red
-    })
-  }
-
   return {
     labels: data.map(h => new Date(h.date)),
     datasets
   }
 }
 
-const MixedChart = ({data, height}) => (
+const ReanimationChart = ({data, height}) => (
   <div style={{padding: '1em'}}>
     <Bar data={formatData(data)} options={options} height={height} />
   </div>
 )
 
-MixedChart.defaultProps = {
+ReanimationChart.defaultProps = {
   height: null
 }
 
-MixedChart.propTypes = {
+ReanimationChart.propTypes = {
   data: PropTypes.array.isRequired,
   height: PropTypes.number
 }
 
-export default MixedChart
+export default ReanimationChart

--- a/components/counters.js
+++ b/components/counters.js
@@ -4,11 +4,13 @@ import PropTypes from 'prop-types'
 import Counter from './counter'
 
 const Counters = ({report}) => {
-  const {casConfirmes, deces} = report || {}
+  const {reanimation, hospitalises, casConfirmes, deces} = report || {}
 
   return (
     <div className='stats'>
       <div className='counters'>
+        <Counter value={reanimation || '?'} label='réanimation' color='darkerGrey' />
+        <Counter value={hospitalises || '?'} label='hospitalisés' color='darkGrey' />
         <Counter value={casConfirmes || '?'} label='cas confirmés' color='orange' />
         <Counter value={deces || '?'} label='décès' color='red' />
       </div>

--- a/components/counters.js
+++ b/components/counters.js
@@ -4,14 +4,14 @@ import PropTypes from 'prop-types'
 import Counter from './counter'
 
 const Counters = ({report}) => {
-  const {hospitalises, reanimation, casConfirmes, deces} = report || {}
+  const {casConfirmes, hospitalises, reanimation, deces} = report || {}
 
   return (
     <div className='stats'>
       <div className='counters'>
+        <Counter value={casConfirmes || '?'} label='cas confirmés' color='orange' />
         <Counter value={hospitalises || '?'} label='hospitalisés' color='darkGrey' />
         <Counter value={reanimation || '?'} label='réanimation' color='darkerGrey' />
-        <Counter value={casConfirmes || '?'} label='cas confirmés' color='orange' />
         <Counter value={deces || '?'} label='décès' color='red' />
       </div>
       <style jsx>{`

--- a/components/counters.js
+++ b/components/counters.js
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types'
 import Counter from './counter'
 
 const Counters = ({report}) => {
-  const {reanimation, hospitalises, casConfirmes, deces} = report || {}
+  const {hospitalises, reanimation, casConfirmes, deces} = report || {}
 
   return (
     <div className='stats'>
       <div className='counters'>
-        <Counter value={reanimation || '?'} label='réanimation' color='darkerGrey' />
         <Counter value={hospitalises || '?'} label='hospitalisés' color='darkGrey' />
+        <Counter value={reanimation || '?'} label='réanimation' color='darkerGrey' />
         <Counter value={casConfirmes || '?'} label='cas confirmés' color='orange' />
         <Counter value={deces || '?'} label='décès' color='red' />
       </div>

--- a/components/national-statistics.js
+++ b/components/national-statistics.js
@@ -6,10 +6,12 @@ import Counters from './counters'
 import MixedChart from './charts/mixed-chart'
 import ConfirmesChart from './charts/confirmes-chart'
 import DecesChart from './charts/deces-chart'
+import ReanimationChart from './charts/reanimation-chart'
+import HospitalisesChart from './charts/hospitalises-chart'
 
 const charts = {
   mixed: {
-    name: 'Cas confirmés & décès',
+    name: 'Tout afficher',
     chart: MixedChart
   },
   confirmed: {
@@ -19,6 +21,14 @@ const charts = {
   deces: {
     name: 'Décès',
     chart: DecesChart
+  },
+  reanimation: {
+    name: 'Réanimation',
+    chart: ReanimationChart
+  },
+  hospitalises: {
+    name: 'Hospitalisés',
+    chart: HospitalisesChart
   }
 }
 
@@ -54,6 +64,7 @@ const NationalStatistics = () => {
         .charts-list {
           display: flex;
           justify-content: space-around;
+          flex-wrap: wrap;
           align-items: center;
         }
 
@@ -61,6 +72,7 @@ const NationalStatistics = () => {
           background-color: ${Theme.alt};
           color: #fff;
           border-radius: 4px;
+          margin: .2em 0;
           padding: 0.2em 0.4em;
         }
 

--- a/components/national-statistics.js
+++ b/components/national-statistics.js
@@ -70,6 +70,7 @@ const NationalStatistics = () => {
 
         .chart-name {
           background-color: ${Theme.alt};
+          text-align: center;
           color: #fff;
           border-radius: 4px;
           margin: .2em 0;

--- a/components/national-statistics.js
+++ b/components/national-statistics.js
@@ -14,6 +14,14 @@ const charts = {
     name: 'Tout afficher',
     chart: MixedChart
   },
+  hospitalises: {
+    name: 'Hospitalisés',
+    chart: HospitalisesChart
+  },
+  reanimation: {
+    name: 'Réanimation',
+    chart: ReanimationChart
+  },
   confirmed: {
     name: 'Cas confirmés',
     chart: ConfirmesChart
@@ -21,14 +29,6 @@ const charts = {
   deces: {
     name: 'Décès',
     chart: DecesChart
-  },
-  reanimation: {
-    name: 'Réanimation',
-    chart: ReanimationChart
-  },
-  hospitalises: {
-    name: 'Hospitalisés',
-    chart: HospitalisesChart
   }
 }
 

--- a/components/national-statistics.js
+++ b/components/national-statistics.js
@@ -14,6 +14,10 @@ const charts = {
     name: 'Tout afficher',
     chart: MixedChart
   },
+  confirmed: {
+    name: 'Cas confirmés',
+    chart: ConfirmesChart
+  },
   hospitalises: {
     name: 'Hospitalisés',
     chart: HospitalisesChart
@@ -21,10 +25,6 @@ const charts = {
   reanimation: {
     name: 'Réanimation',
     chart: ReanimationChart
-  },
-  confirmed: {
-    name: 'Cas confirmés',
-    chart: ConfirmesChart
   },
   deces: {
     name: 'Décès',

--- a/components/national-statistics.js
+++ b/components/national-statistics.js
@@ -62,10 +62,10 @@ const NationalStatistics = () => {
 
       <style jsx>{`
         .charts-list {
-          display: flex;
-          justify-content: space-around;
-          flex-wrap: wrap;
-          align-items: center;
+          display: grid;
+          grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+          grid-gap: 0.2em;
+          margin: 0.5em;
         }
 
         .chart-name {

--- a/components/react-map-gl/layers.js
+++ b/components/react-map-gl/layers.js
@@ -61,3 +61,65 @@ export const decesCountLayer = {
     'text-size': 16
   }
 }
+
+export const hospitalisesLayer = {
+  id: 'hospitalises',
+  type: 'circle',
+  source: 'hospitalises',
+  filter: ['>', 'hospitalises', 0],
+  paint: {
+    'circle-opacity': 0.6,
+    'circle-color': colors.darkGrey,
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['sqrt', ['number', ['get', 'hospitalises']]],
+      0,
+      10,
+      30,
+      80
+    ]
+  }
+}
+
+export const hospitalisesCountLayer = {
+  id: 'hospitalises-count',
+  type: 'symbol',
+  source: 'hospitalises',
+  filter: ['>', 'hospitalises', 0],
+  layout: {
+    'text-field': '{hospitalises}',
+    'text-size': 16
+  }
+}
+
+export const reanimationLayer = {
+  id: 'reanimation',
+  type: 'circle',
+  source: 'reanimation',
+  filter: ['>', 'reanimation', 0],
+  paint: {
+    'circle-opacity': 0.6,
+    'circle-color': colors.darkerGrey,
+    'circle-radius': [
+      'interpolate',
+      ['linear'],
+      ['sqrt', ['number', ['get', 'reanimation']]],
+      0,
+      10,
+      30,
+      80
+    ]
+  }
+}
+
+export const reanimationCountLayer = {
+  id: 'reanimation-count',
+  type: 'symbol',
+  source: 'reanimation',
+  filter: ['>', 'reanimation', 0],
+  layout: {
+    'text-field': '{reanimation}',
+    'text-size': 16
+  }
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -23,7 +23,7 @@ function consolidate(records) {
       .reduce((acc, row) => {
         defaults(acc, row)
         return acc
-      }, {}), ['casConfirmes', 'deces', 'reanimation', 'date', 'code', 'nom'])
+      }, {}), ['casConfirmes', 'deces', 'reanimation', 'hospitalises', 'date', 'code', 'nom'])
   })
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -10,7 +10,16 @@ import theme from '../styles/theme'
 
 import Page from '../layouts/main'
 
-import {casConfirmesLayer, casConfirmesCountLayer, decesLayer, decesCountLayer} from '../components/react-map-gl/layers'
+import {
+  casConfirmesLayer,
+  casConfirmesCountLayer,
+  decesLayer,
+  decesCountLayer,
+  hospitalisesLayer,
+  hospitalisesCountLayer,
+  reanimationLayer,
+  reanimationCountLayer
+} from '../components/react-map-gl/layers'
 
 import ScreenPage from '../layouts/screen'
 import MobilePage from '../layouts/mobile'
@@ -146,6 +155,20 @@ const MainPage = ({data, dates, isIframe, isGouv}) => {
       layers: [decesLayer, decesCountLayer]
     },
     {
+      name: 'Carte des hospitalisations',
+      category: 'régionale',
+      properties: 'hospitalises',
+      data: regionsReport,
+      layers: [hospitalisesLayer, hospitalisesCountLayer]
+    },
+    {
+      name: 'Carte des cas en réanimation',
+      category: 'régionale',
+      properties: 'reanimation',
+      data: regionsReport,
+      layers: [reanimationLayer, reanimationCountLayer]
+    },
+    {
       name: 'Carte des cas confirmés',
       category: 'départementale',
       data: departementsReport,
@@ -158,6 +181,20 @@ const MainPage = ({data, dates, isIframe, isGouv}) => {
       data: departementsReport,
       properties: 'deces',
       layers: [decesLayer, decesCountLayer]
+    },
+    {
+      name: 'Carte des hospitalisations',
+      category: 'départementale',
+      properties: 'hospitalises',
+      data: departementsReport,
+      layers: [hospitalisesLayer, hospitalisesCountLayer]
+    },
+    {
+      name: 'Carte des cas en réanimation',
+      category: 'départementale',
+      properties: 'reanimation',
+      data: departementsReport,
+      layers: [reanimationLayer, reanimationCountLayer]
     }
   ]
 


### PR DESCRIPTION
- Ajout des métriques `reanimation` et `hospitalises`
![Screenshot_2020-03-20 Tableau de bord de suivi de l’épidémie de coronavirus en France(2)](https://user-images.githubusercontent.com/45098730/77196227-36ef6300-6ae3-11ea-849d-b7747f4caf3b.png)

- Modification de la liste des métriques 
![Screenshot_2020-03-20 Tableau de bord de suivi de l’épidémie de coronavirus en France(3)](https://user-images.githubusercontent.com/45098730/77196318-5e463000-6ae3-11ea-98ce-7e19a4ba9c93.png)

-  Affiche `undefined` au lieu de `NaN` quand il n'y a pas de données dans le graphique
![undefined](https://user-images.githubusercontent.com/45098730/77196571-e75d6700-6ae3-11ea-929d-85e3f3645f64.png)

