### PR TITLE
Change the order for the bar to Décès>Guéris>Réa>Hosp>Confirmés 

### DIFF
--- a/components/charts/mixed-chart.js
+++ b/components/charts/mixed-chart.js
@@ -47,6 +47,14 @@ const formatData = data => {
     })
   }
 
+  if (data.some(h => h.gueris)) {
+    datasets.push({
+      label: 'Retours à domicile',
+      data: data.map(h => h.gueris || null),
+      backgroundColor: colors.green
+    })
+  }
+
   if (data.some(h => h.reanimation)) {
     datasets.push({
       label: 'En réanimation',
@@ -66,14 +74,6 @@ const formatData = data => {
         return null
       }),
       backgroundColor: colors.darkGrey
-    })
-  }
-
-  if (data.some(h => h.gueris)) {
-    datasets.push({
-      label: 'Retours à domicile',
-      data: data.map(h => h.gueris || null),
-      backgroundColor: colors.green
     })
   }
 


### PR DESCRIPTION
This order is preferred compared to the original  Décès>Réa>Hosp>Guéris>Confirmés, because with the new order the bottom of the bar directly shows the cases that "exited" the system and the top part what remains.