### PR TITLE
Fix fullscreen button position

### DIFF
--- a/components/react-map-gl/index.js
+++ b/components/react-map-gl/index.js
@@ -141,7 +141,7 @@ const Map = () => {
           position: absolute;
           display: flex;
           justify-content: space-between;
-          align-items: end;
+          align-items: start;
           width: 100%;
           padding: 0.5em;
         }


### PR DESCRIPTION
Salut @jdesboeufs, "prem's" à soumettre une PR à propos de la carte sur : https://www.gouvernement.fr/info-coronavirus/carte-et-donnees

Il s'agît vraiment d'un bug très léger "esthétique". Lorsque l'on clique sur la dropdown de sélection de donnée, le bouton full screen est décalé vers le bas :)

![image](https://user-images.githubusercontent.com/6597721/77801759-c499f800-7079-11ea-81e0-21a124d64bef.png)

J'ai corrigé le souci :) J'ai changé une petite propriété flex ;)