### PR TITLE
Fix attribution

### DIFF
--- a/components/react-map-gl/index.js
+++ b/components/react-map-gl/index.js
@@ -99,7 +99,7 @@ const Map = () => {
         <Source
           type='geojson'
           id='cas-confirmes'
-          attribution='Données Santé publique France et ARS'
+          attribution='Données Santé publique France'
           data={maps[selectedMapIdx].data}
         >
           {maps[selectedMapIdx].layers.map(layer => (


### PR DESCRIPTION
Le texte d'information semble indiquer que les données affichées sur la carte proviennent (uniquement) de Santé publique France. Si c'est le cas, alors il n'est pas nécessaire de créditer les ARS dans les attributions de la carte.

![image](https://user-images.githubusercontent.com/6597721/77808335-30d12780-708b-11ea-9715-40417b1cad72.png)

Si certaines données proviennent bien des ARS, alors il convient de le mentionner dans le bloc information car actuellement ce n'est pas le cas.

Merci d'avance :+1: 