### PR TITLE
Fix css: bad background-color value

### DIFF
--- a/components/map-selector.js
+++ b/components/map-selector.js
@@ -81,7 +81,7 @@ const MapSelector = ({mapIdx, selectMap}) => {
         }
 
         .menu-item.selected:hover {
-          background-color: none;
+          background-color: transparent;
           cursor: initial;
         }
 


### PR DESCRIPTION
La valeur `none` n'est pas une valeur valide pour la propriété `background-color`.
J'ai simplement remplacé par la valeur `transparent`.

:+1: 