### PR TITLE
Améliore le rendu des boutons de navigation sur mobile

### DIFF
--- a/layouts/mobile.js
+++ b/layouts/mobile.js
@@ -2,9 +2,8 @@ import React, {useState, useContext} from 'react'
 import {FileText, Map, BarChart2} from 'react-feather'
 
 import colors from '../styles/colors'
-import theme from '../styles/theme'
 
-import {AppContext} from '../pages'
+import {AppContext, ThemeContext} from '../pages'
 
 import DateNav from '../components/date-nav'
 import Scrollable from '../components/scrollable'
@@ -25,6 +24,7 @@ const MobilePage = () => {
   const [selectedView, setSelectedView] = useState('stats')
 
   const app = useContext(AppContext)
+  const theme = useContext(ThemeContext)
 
   const handleClick = view => {
     app.setSelectedLocation(null)
@@ -69,17 +69,7 @@ const MobilePage = () => {
         }
 
         .view-selector > div.selected {
-          border-top: 2px solid ${colors.blue};
-        }
-
-        @media (max-width: ${theme.mobileDisplay}) {
-          .view-selector {
-            display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            justify-content: center;
-            align-items: center;
-            background-color: #fff;
-          }
+          border-top: 4px solid ${theme.primary};
         }
       `}</style>
     </div>

--- a/layouts/mobile.js
+++ b/layouts/mobile.js
@@ -40,13 +40,13 @@ const MobilePage = () => {
 
       <div className='view-selector'>
         <div className={`${selectedView === 'stats' ? 'selected' : ''}`} onClick={() => handleClick('stats')}>
-          <BarChart2 />
+          <BarChart2 size={32} color={selectedView === 'stats' ? theme.primary : colors.black} />
         </div>
         <div className={`${selectedView === 'map' ? 'selected' : ''}`} onClick={() => handleClick('map')}>
-          <Map />
+          <Map size={32} color={selectedView === 'map' ? theme.primary : colors.black} />
         </div>
         <div className={`${selectedView === 'informations' ? 'selected' : ''}`} onClick={() => handleClick('informations')}>
-          <FileText />
+          <FileText size={32} color={selectedView === 'informations' ? theme.primary : colors.black} />
         </div>
       </div>
 
@@ -60,12 +60,19 @@ const MobilePage = () => {
         }
 
         .view-selector {
-          display: none;
+          z-index: 1;
+          display: grid;
+          grid-template-columns: 1fr 1fr 1fr;
+          justify-content: center;
+          align-items: center;
+          background-color: #fff;
+          box-shadow: 0 -1px 4px ${colors.lightGrey};
         }
 
         .view-selector > div {
           padding: 0.5em;
           margin: auto;
+          margin-bottom: -4px;
         }
 
         .view-selector > div.selected {


### PR DESCRIPTION
## Modifications
- Agrandi les boutons
- Affiche le menu sélectionné en surbrillance
- Ajout une ombre 

### Avant
<img width="400" alt="" src="https://user-images.githubusercontent.com/7040549/78274901-2abacb00-7511-11ea-9526-9b606ba6e723.jpg">

### Après
<img width="400" alt="" src="https://user-images.githubusercontent.com/7040549/78274914-2ee6e880-7511-11ea-9f54-2c174f9fccf1.jpg">
