### PR TITLE
Désactive le scroll zoom dans une iframe

### DIFF
--- a/components/react-map-gl/index.js
+++ b/components/react-map-gl/index.js
@@ -71,12 +71,12 @@ const Map = () => {
   return (
     <div className='map-container'>
       <div className='controls'>
-        <div className='control'>
+        <div className='custom-control'>
           <MapSelector mapIdx={selectedMapIdx} selectMap={setSelectedMapIdx} />
         </div>
 
         {isIframe && (
-          <div className='control maximize'>
+          <div className='custom-control maximize'>
             <a href={SITE_URL} target='_top'><Maximize2 style={{verticalAlign: 'middle'}} /></a>
           </div>
         )}
@@ -89,12 +89,18 @@ const Map = () => {
         width='100%'
         height='100%'
         mapStyle='https://etalab-tiles.fr/styles/osm-bright/style.json'
+        scrollZoom={!isIframe}
         {...settings}
         interactiveLayerIds={maps[selectedMapIdx].layers.map(layer => layer.id)}
         onViewportChange={setViewport}
         onHover={isMobileDevice ? null : onHover}
         onClick={onClick}
       >
+        {isIframe && (
+          <div className='control navigation'>
+            <NavigationControl showCompass={false} />
+          </div>
+        )}
 
         <Source
           type='geojson'
@@ -146,11 +152,21 @@ const Map = () => {
           padding: 0.5em;
         }
 
-        .control {
+        .custom-control {
           background-color: #000000aa;
           color: #fff;
           border-radius: 4px;
           margin: 0;
+        }
+
+        .control {
+          position: absolute;
+          margin: 0.5em;
+        }
+
+        .navigation {
+          top: 40px;
+          right: 0;
         }
 
         .maximize {

--- a/components/react-map-gl/index.js
+++ b/components/react-map-gl/index.js
@@ -30,6 +30,7 @@ const Map = () => {
 
   const [map, setMap] = useState()
   const [hovered, setHovered] = useState(null)
+  const enableZoom = isIframe && isMobileDevice
 
   const mapRef = useCallback(ref => {
     if (ref) {
@@ -89,14 +90,14 @@ const Map = () => {
         width='100%'
         height='100%'
         mapStyle='https://etalab-tiles.fr/styles/osm-bright/style.json'
-        scrollZoom={!isIframe}
+        scrollZoom={enableZoom}
         {...settings}
         interactiveLayerIds={maps[selectedMapIdx].layers.map(layer => layer.id)}
         onViewportChange={setViewport}
         onHover={isMobileDevice ? null : onHover}
         onClick={onClick}
       >
-        {isIframe && (
+        {!enableZoom && (
           <div className='control navigation'>
             <NavigationControl showCompass={false} />
           </div>

--- a/components/react-map-gl/index.js
+++ b/components/react-map-gl/index.js
@@ -1,5 +1,5 @@
 import React, {useState, useCallback, useContext} from 'react'
-import ReactMapGL, {Source, Layer, Popup} from 'react-map-gl'
+import ReactMapGL, {NavigationControl, Source, Layer, Popup} from 'react-map-gl'
 import {Maximize2} from 'react-feather'
 
 import {AppContext} from '../../pages'
@@ -16,8 +16,6 @@ const settings = {
 }
 
 const Map = () => {
-  const [selectedMapIdx, setSelectedMapIdx] = useState(1)
-
   const {
     selectedLocationReport,
     setSelectedLocation,
@@ -30,6 +28,10 @@ const Map = () => {
 
   const [map, setMap] = useState()
   const [hovered, setHovered] = useState(null)
+  const [selectedMapIdx, setSelectedMapIdx] = useState(1)
+  const [showZoomMessage, setShowZoomMessage] = useState(false)
+  const [zoomMessageCoolDown, setZoomMessageCoolDown] = useState(true)
+
   const enableZoom = isIframe && isMobileDevice
 
   const mapRef = useCallback(ref => {
@@ -69,6 +71,15 @@ const Map = () => {
     setHovered(null)
   }
 
+  const displayAlert = () => {
+    if (!showZoomMessage && zoomMessageCoolDown) {
+      setShowZoomMessage(true)
+      setZoomMessageCoolDown(false)
+      setTimeout(() => setShowZoomMessage(null), 5000)
+      setTimeout(() => setZoomMessageCoolDown(true), 60000)
+    }
+  }
+
   return (
     <div className='map-container'>
       <div className='controls'>
@@ -83,6 +94,13 @@ const Map = () => {
         )}
       </div>
 
+      {showZoomMessage && (
+        <div className='zoom-message'>
+          <p>Le zoom à la souris est désactivé.</p>
+          <p>Merci d’utiliser les contrôles +/- situés en haut à droite.</p>
+        </div>
+      )}
+
       <ReactMapGL
         reuseMaps
         ref={mapRef}
@@ -96,6 +114,7 @@ const Map = () => {
         onViewportChange={setViewport}
         onHover={isMobileDevice ? null : onHover}
         onClick={onClick}
+        onWheel={enableZoom ? null : displayAlert}
       >
         {!enableZoom && (
           <div className='control navigation'>
@@ -168,6 +187,22 @@ const Map = () => {
         .navigation {
           top: 40px;
           right: 0;
+        }
+
+        .zoom-message {
+          z-index: 999;
+          position: absolute;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
+          align-items: center;
+          width: 100%;
+          height: 100%;
+          background-color: #000000aa;
+          color: #fff;
+          padding: 30%;
+          font-size: xx-large;
+          text-align: center;
         }
 
         .maximize {


### PR DESCRIPTION

<img width="1079" alt="Capture d’écran 2020-04-02 à 19 57 26" src="https://user-images.githubusercontent.com/7040549/78282257-3fe92700-751c-11ea-9f74-bace2021aecc.png">


- Désactive le scroll zoom dans une iframe
- Affiche les controls de zoom/dézoom de la carte
- Affiche un message d'information pendant 3 secondes si un scroll zoom est détecté. Ce message ne se ré-affichera pas avant une minute.

Fix #54 