### PR TITLE
Corrige le calcule des limites de la carte 

### DIFF
--- a/components/react-map-gl/map.js
+++ b/components/react-map-gl/map.js
@@ -4,16 +4,22 @@ import ReactMapGL, {Source, Layer, WebMercatorViewport} from 'react-map-gl'
 
 import geo from '../../geo.json'
 
+const defaultViewport = {
+  latitude: 46.9,
+  longitude: 1.7,
+  zoom: 5
+}
+
 const Map = ({code, data, layers, hideAttribution, onHover, onClick, children}) => {
   const mapRef = useRef()
 
-  const [viewport, setViewport] = useState(null)
+  const [viewport, setViewport] = useState(defaultViewport)
 
   const handleResize = useCallback(() => {
     if (mapRef && mapRef.current) {
       const {width, height} = mapRef.current.getBoundingClientRect()
 
-      if (width > 0 && height > 0) {
+      if (width > 50 && height > 50) {
         const {bbox} = geo[code]
         const viewport = new WebMercatorViewport({width, height})
           .fitBounds([[bbox[0], bbox[1]], [bbox[2], bbox[3]]], {padding: 20})


### PR DESCRIPTION
Cette PR corrige les erreurs de calcule dans `WebMercatorViewport` qui peuvent arriver lorsque que la hauteur et la largeur de l'écran détecté sont trop petites.  