### PR TITLE
Ajout de la propriété z-index au header de CovidTestStatistics

### DIFF
--- a/components/layouts/covid-tests/covid-tests-statistics.js
+++ b/components/layouts/covid-tests/covid-tests-statistics.js
@@ -146,6 +146,7 @@ const CovidTestsStatistics = () => {
           background-color: white;
           padding: ${isMobileDevice ? '0.2em' : 0};
           box-shadow: 0 1px 4px ${colors.lightGrey};
+          z-index: 1;
         }
 
         .header h3 {


### PR DESCRIPTION
* capture d'écran
  * avant :
![before](https://user-images.githubusercontent.com/45098730/83161549-df83f980-a108-11ea-9dd0-cfa8e7c50954.png)

  * après :
![after](https://user-images.githubusercontent.com/45098730/83161577-e90d6180-a108-11ea-9f37-74c4fcbc7de7.png)

