### PR TITLE
Nom des villes au-dessus des layers de SyntheseMap

### DIFF
--- a/components/layouts/synthese/synthese-map.js
+++ b/components/layouts/synthese/synthese-map.js
@@ -75,8 +75,8 @@ export const SyntheseMap = ({hovered, isDROM}) => {
           attribution='Données Ministère des Solidarités et de la Santé'
           url='https://etalab-tiles.fr/data/decoupage-administratif.json'
         >
-          <Layer {...indicateurSynthese} />
-          <Layer {...regionsLayer} />
+          <Layer beforeId='place-town' {...indicateurSynthese} />
+          <Layer beforeId='place-town' {...regionsLayer} />
         </Source>
 
         <style jsx>{`


### PR DESCRIPTION
- Ajout de la `prop` `beforeId` aux "layers" de `SyntheseMap`

* capture d'écran : 
  * avant : 
![before-id](https://user-images.githubusercontent.com/45098730/83164575-ae0d2d00-a10c-11ea-815e-2da1c968b3b7.png)

  * après : 
![after-id](https://user-images.githubusercontent.com/45098730/83164584-b06f8700-a10c-11ea-92ec-97b9cb2ec56f.png)

