### PR TITLE
Update map-selector.js - Modification orientation Chevron

### DIFF
--- a/components/map-selector.js
+++ b/components/map-selector.js
@@ -24,7 +24,7 @@ const MapSelector = ({selectedMapId, maps, selectMap, selectStat}) => {
   return (
     <div className='switch'>
       <div className='header' onClick={handleClick}>
-        <span>{selectedMap.name}</span> {isOpen ? <ChevronDown /> : <ChevronUp />}
+        <span>{selectedMap.name}</span> {isOpen ? <ChevronUp /> : <ChevronDown />}
       </div>
       {isOpen && (
         <div className='menu'>


### PR DESCRIPTION
Le chevron situé sur la box de sélection de la carte est inversé (dirigé vers le haut lorsque la liste déroulante est fermée, et inversement), alors que la logique voudrait que ce soit l'inverse.