### PR TITLE
Correction des totaux de décés

### DIFF
--- a/components/layouts/big-picture/big-picture-counters.js
+++ b/components/layouts/big-picture/big-picture-counters.js
@@ -13,7 +13,7 @@ const Counters = props => {
 
   const totalDeces = (deces || 0) + (decesEhpad || 0)
   const previousReport = props.previousReport || {}
-  const previousTotalDeces = (previousReport.deces || 0) + (previousReport.decesEhpad || 0)
+  const previousTotalDeces = previousReport.deces && previousReport.decesEhpad && deces && decesEhpad ? (previousReport.deces || 0) + (previousReport.decesEhpad || 0) : null
 
   const details = {
     casConfirmes: 'Nombre cumulé de cas de COVID-19 confirmés par un test positif. <br />',


### PR DESCRIPTION
Corrige l'affichage de la différences des totaux de l'indicateur "cumul des décés"

![totalDeces](https://user-images.githubusercontent.com/56537238/92497871-2d28fb80-f1fa-11ea-8112-f2994d8b2b58.png)


