### PR TITLE
Corrige l'affichage des données régionales sur l'onglet "Carte des indicateurs"

### DIFF
--- a/components/layouts/covid-tests/index.js
+++ b/components/layouts/covid-tests/index.js
@@ -151,7 +151,6 @@ const CovidTests = props => {
 
     return () => {
       isCancelled = true
-      setForcedDate(null)
     }
   }, [date, selectedLocation, setForcedDate])
 

--- a/components/layouts/indicators/index.js
+++ b/components/layouts/indicators/index.js
@@ -153,7 +153,6 @@ const Indicators = props => {
 
     return () => {
       isCancelled = true
-      setForcedDate(null)
     }
   }, [date, selectedLocation, selectedStat, setForcedDate])
 

--- a/components/layouts/indicators/indicators-statistics.js
+++ b/components/layouts/indicators/indicators-statistics.js
@@ -18,9 +18,8 @@ import {IndicatorsContext} from '.'
 
 const IndicatorsStatistics = () => {
   const {selectedLocation, setSelectedLocation, isMobileDevice} = useContext(AppContext)
-  const {selectedDate} = useContext(IndicatorsContext)
 
-  const {report, selectedStat, setSelectedStat} = useContext(IndicatorsContext)
+  const {report, selectedDate, selectedStat, setSelectedStat} = useContext(IndicatorsContext)
 
   const [locationType, code] = selectedLocation.split('-')
 
@@ -51,7 +50,7 @@ const IndicatorsStatistics = () => {
       </div>
 
       <div className='indicators-container'>
-        {selectedLocation.split('-')[0] === 'REG' ? (
+        {locationType === 'REG' ? (
           <>
             {departementsRegion.map(r => (
               <div key={r.code}>
@@ -61,7 +60,9 @@ const IndicatorsStatistics = () => {
             ))}
           </>
         ) : (
-          report && Object.keys(indicatorsList).map(indicator => {
+          report &&
+          !report.code.includes('REG') && // `locationType` peut être désynchronisé de `report`
+          Object.keys(indicatorsList).map(indicator => {
             const {label, details, min, max} = indicatorsList[indicator]
             const value = getIndicatorValue(indicator)
             return (


### PR DESCRIPTION
L'absence de données à la maille régionale concernant les indicateurs a pour effet de déclencher le filtre visant à n'afficher que les données les plus récentes disponible. 
Ce qui provoque une colorisation des départements en gris et un décalage de la date sélectionnée alors que les données départementales sont quant à elle bien présentes.

Ce correctif a pour effet de générer un rapport concernant les indicateurs pour chaque région en attribuant la valeur `true` si au moins un de ses départements contient une valeur sinon `null`. Cette variable permet de contourner le système de récupération des données les plus récente disponible.