### PR TITLE
Mise à jour du seuil du taux d'occupation des lits en réanimation

### DIFF
--- a/components/layouts/indicators/index.js
+++ b/components/layouts/indicators/index.js
@@ -132,8 +132,8 @@ const Indicators = props => {
   const {date, forcedDate, selectedLocation, isMobileDevice, setForcedDate} = useContext(AppContext)
   const selectedDate = forcedDate || date
 
-  const [selectedMapId, setSelectedMapId] = useState('Taux d’incidence')
-  const [selectedStat, setSelectedStat] = useState('tauxIncidence')
+  const [selectedMapId, setSelectedMapId] = useState('Taux d’occupation des lits en réanimation')
+  const [selectedStat, setSelectedStat] = useState('tauxOccupationRea')
   const [report, setReport] = useState(null)
 
   const Component = isMobileDevice ? MobileIndicators : DesktopIndicators

--- a/components/layouts/indicators/indicators-departement.js
+++ b/components/layouts/indicators/indicators-departement.js
@@ -95,9 +95,9 @@ const IndicatorsDepartement = ({code, allIndicators = true}) => {
       <div className='indicators'>
         {allIndicators ? (
           <>
+            <Indicator label='Taux d’occupation des lits en réanimation' value={tauxOccupationRea} color={tauxOccupationReaColor} />
             <Indicator label='Taux d’incidence' value={tauxIncidence} color={tauxIncidenceColor} />
             <Indicator label='R - Nombre de reproduction effectif' value={tauxReproductionEffectif} color={tauxReproductionEffectifColor} />
-            <Indicator label='Taux d’occupation des lits en réanimation' value={tauxOccupationRea} color={tauxOccupationReaColor} />
             <Indicator label='Taux de positivité des tests RT-PCR' value={tauxPositiviteTests} color={tauxPositiviteTestsColor} />
           </>
         ) : (

--- a/components/layouts/indicators/indicators-maps.js
+++ b/components/layouts/indicators/indicators-maps.js
@@ -3,6 +3,14 @@ import {IndicatorsMap, HoveredInfos, onSelect, interactiveLayersIds} from './ind
 
 const maps = [
   {
+    name: 'Taux d’occupation des lits en réanimation',
+    type: IndicatorsMap,
+    property: 'tauxOccupationRea',
+    onSelect,
+    hovered: (feature, options) => <HoveredInfos feature={feature} options={options} />,
+    interactiveLayersIds
+  },
+  {
     name: 'Taux d’incidence',
     type: IndicatorsMap,
     property: 'tauxIncidence',
@@ -14,14 +22,6 @@ const maps = [
     name: 'R - Nombre de reproduction effectif',
     type: IndicatorsMap,
     property: 'tauxReproductionEffectif',
-    onSelect,
-    hovered: (feature, options) => <HoveredInfos feature={feature} options={options} />,
-    interactiveLayersIds
-  },
-  {
-    name: 'Taux d’occupation des lits en réanimation',
-    type: IndicatorsMap,
-    property: 'tauxOccupationRea',
     onSelect,
     hovered: (feature, options) => <HoveredInfos feature={feature} options={options} />,
     interactiveLayersIds

--- a/lib/indicators.js
+++ b/lib/indicators.js
@@ -14,7 +14,7 @@ export const indicatorsList = {
   tauxOccupationRea: {
     label: 'Taux d’occupation des lits en réanimation',
     details: 'Taux d’occupation des lits en réanimation par des patients atteints du COVID-19 par rapport à la capacité initiale en réanimation, par région',
-    min: 40,
+    min: 30,
     max: 60
   },
   tauxPositiviteTests: {

--- a/lib/indicators.js
+++ b/lib/indicators.js
@@ -1,4 +1,10 @@
 export const indicatorsList = {
+  tauxOccupationRea: {
+    label: 'Taux d’occupation des lits en réanimation',
+    details: 'Taux d’occupation des lits en réanimation par des patients atteints du COVID-19 par rapport à la capacité initiale en réanimation, par région',
+    min: 30,
+    max: 60
+  },
   tauxIncidence: {
     label: 'Taux d’incidence',
     details: 'Activité épidémique : nombre de patients ayant un test RT-PCR positif pour 100 000 habitants par semaine (cumul sur 7 jours glissants, données SI-DEP)',
@@ -10,12 +16,6 @@ export const indicatorsList = {
     details: 'Nombre moyen de personnes contaminées par chaque personne atteinte du COVID-19 (basé sur les données Oscour : passages aux urgences pour suspicion COVID-19)',
     min: 1,
     max: 1.5
-  },
-  tauxOccupationRea: {
-    label: 'Taux d’occupation des lits en réanimation',
-    details: 'Taux d’occupation des lits en réanimation par des patients atteints du COVID-19 par rapport à la capacité initiale en réanimation, par région',
-    min: 30,
-    max: 60
   },
   tauxPositiviteTests: {
     label: 'Taux de positivité des tests RT-PCR',


### PR DESCRIPTION
- Mise à jour du seuil minimal du taux d'occupation des lits en réanimation de 30 à 40
- Le taux d'occupation des lits en réanimation est devient l'indicateur par défaut au chargement de l'onglet "Carte des indicateurs"