### PR TITLE
remove diffdetail from cas confirmes

### DIFF
--- a/components/layouts/big-picture/big-picture-counters.js
+++ b/components/layouts/big-picture/big-picture-counters.js
@@ -86,7 +86,6 @@ const Counters = props => {
           previousValue={previousReport.casConfirmes}
           label='cas confirmés'
           details={details.casConfirmes}
-          diffDetail=''
           color='orange'
           isBig
         />}

--- a/components/layouts/big-picture/big-picture-counters.js
+++ b/components/layouts/big-picture/big-picture-counters.js
@@ -86,7 +86,7 @@ const Counters = props => {
           previousValue={previousReport.casConfirmes}
           label='cas confirmés'
           details={details.casConfirmes}
-          diffDetail='Chiffre minimal et non consolidé en raison de difficultés identifiées dans la remontée des résultats de tests vers Santé publique France'
+          diffDetail=''
           color='orange'
           isBig
         />}


### PR DESCRIPTION
Plus besoin d'avertir sur le "Chiffre minimal et non consolidé" puisqu'il n y a plus de "difficultés identifiées dans la remontée des résultats de tests vers Santé publique France" qu'il y avait il y a quelques semaines