### PR TITLE
Rectify tauxIncidence details

### DIFF
--- a/lib/indicators.js
+++ b/lib/indicators.js
@@ -7,7 +7,7 @@ export const indicatorsList = {
   },
   tauxIncidence: {
     label: 'Taux d’incidence',
-    details: 'Nombre de nouvelles personnes testées positives (RT-PCR) rapporté à la taille de la population.<br /> Il est exprimé pour 100 000 habitants et permet de comparer des zones géographiques entre elles. Le taux d’incidence peut fluctuer en fonction des activités de dépistage et de délais de rendu de résultat.',
+    details: 'Nombre de personnes, sur une semaine glissante, testées positives (RT-PCR et test antigénique) pour la première fois depuis plus de 60 jours rapporté à la taille de la population.<br /> Il est exprimé pour 100 000 habitants et permet de comparer des zones géographiques entre elles. Le taux d’incidence peut fluctuer en fonction des activités de dépistage et de délais de rendu de résultat.',
     min: 10,
     max: 50
   },


### PR DESCRIPTION
Rectified tauxIncidence details to match definition from data producer (https://www.data.gouv.fr/fr/datasets/indicateurs-de-suivi-de-lepidemie-de-covid-19/)